### PR TITLE
Fix raise statement in battery_degradation

### DIFF
--- a/hydesign/battery_degradation.py
+++ b/hydesign/battery_degradation.py
@@ -441,7 +441,7 @@ def battery_replacement(
                 ind_q = ind_q + ind_q_new[1:]        
 
         except:
-            raise('This many bateries are not required. Reduce the number.')
+            raise ValueError('This many batteries are not required. Reduce the number.')
 
     return LoC, ind_q, ind_q_last
 


### PR DESCRIPTION
## Summary
- fix raise statement during battery replacement logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hydesign._version')*

------
https://chatgpt.com/codex/tasks/task_b_684a84dbd0bc8321ac7eb76d306a2dcf