### PR TITLE
Ensure degraded wind power below nominal

### DIFF
--- a/hydesign/ems/ems.py
+++ b/hydesign/ems/ems.py
@@ -565,7 +565,7 @@ class ems_long_term_operation(om.ExplicitComponent):
 # Auxiliar functions for ems modelling
 # -----------------------------------------------------------------------
 
-def expand_to_lifetime(x, life_y = 25, intervals_per_hour=1, weeks_per_season_per_year=None, axis=0, additional_intervals=0):
+def expand_to_lifetime(x, life_y = 25, intervals_per_hour=1, weeks_per_season_per_year=None, axis=0, additional_intervals=0, life=None):
     """
     Expands (by repeating) a given variable to match an expected lifetime length.
     
@@ -574,14 +574,17 @@ def expand_to_lifetime(x, life_y = 25, intervals_per_hour=1, weeks_per_season_pe
     Parameters
     ----------
     x: input variable
-    life: lifetime in no of intervals.
+    life: lifetime in number of intervals. If None, it is computed from
+        ``life_y`` and ``intervals_per_hour``.
     weeks_per_season_per_year: None or int.
 
     Returns
     -------
     x_ext: extended variable
     """    
-    life = life_y*365*24*intervals_per_hour+additional_intervals
+    if life is None:
+        life = life_y*365*24*intervals_per_hour
+    life = life + additional_intervals
     if weeks_per_season_per_year == None:
         
         # Extend the data to match the expected lifetime

--- a/hydesign/use_cases/hpp_pywake_p2x.py
+++ b/hydesign/use_cases/hpp_pywake_p2x.py
@@ -239,7 +239,19 @@ class hpp_model(hpp_base):
 
 
 
-            wind_t_ext_deg = expand_to_lifetime(wpp_efficiency*get_wind_ts_degradation_2d(ws=pc_ws, wd=pc_wd, pc=pc, ws_ts=ws, wd_ts=wd, yr=wind_deg_yr, wind_deg=wind_deg, life=ws.size), life_y=life_y, intervals_per_hour=intervals_per_hour)
+            wind_t_ext_deg_raw = expand_to_lifetime(
+                wpp_efficiency*get_wind_ts_degradation_2d(
+                    ws=pc_ws,
+                    wd=pc_wd,
+                    pc=pc,
+                    ws_ts=ws,
+                    wd_ts=wd,
+                    yr=wind_deg_yr,
+                    wind_deg=wind_deg,
+                    life=ws.size),
+                life_y=life_y,
+                intervals_per_hour=intervals_per_hour)
+            wind_t_ext_deg = np.minimum(wind_t_ext_deg_raw, wind_t_ext)
             return [wind_t, loads_rel_ext, wind_t_ext, wind_t_ext_deg]
 
         def pv(surface_tilt, surface_azimuth, solar_MW, DC_AC_ratio, **kwargs):


### PR DESCRIPTION
## Summary
- cap degraded wind output to nominal output
- support `life` argument in `expand_to_lifetime`

## Testing
- `pytest hydesign/tests/test_evaluation.py::test_evaluation_constant_load -q`
- `pytest hydesign/tests/test_evaluation.py::test_evaluation_P2X_bidirectional -q`
- `pytest hydesign/tests/test_evaluation.py::test_evaluation_HiFiEMS -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a8c0ab42883219c73a108ef1a219b