### PR TITLE
Add PyWake P2X example notebook

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,9 +33,10 @@ Explanations of hydesign's core objects can be found in the following tutorials:
 	:caption: Evaluation Tutorials
 
 	notebooks/Quickstart
-	notebooks/Advanced_hpp_model
-	notebooks/HPP_evaluation_P2X
-	notebooks/break_even_price_and_PPA
+        notebooks/Advanced_hpp_model
+        notebooks/HPP_evaluation_P2X
+        notebooks/PyWake_P2X_Example
+        notebooks/break_even_price_and_PPA
 	notebooks/constant_output
 	notebooks/offshore
 	notebooks/Example_ISO_prob

--- a/docs/notebooks/PyWake_P2X_Example.ipynb
+++ b/docs/notebooks/PyWake_P2X_Example.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PyWake P2X Example\n",
+    "\n",
+    "This notebook reproduces the example shown in `hydesign/use_cases/hpp_pywake_p2x.py`.\n",
+    "A hybrid power plant with wind, solar, storage and power-to-gas is evaluated \n",
+    "using a PyWake based wind farm model, and selected outputs are plotted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from hydesign.use_cases.hpp_pywake_p2x import hpp_model\n",
+    "from hydesign.examples import examples_filepath\n",
+    "from py_wake.examples.data.hornsrev1 import Hornsrev1Site\n",
+    "from py_wake.turbulence_models.stf import STF2017TurbulenceModel\n",
+    "from py_wake import NOJ\n",
+    "from py_wake.deflection_models import JimenezWakeDeflection\n",
+    "from py_wake.examples.data.dtu10mw_surrogate import DTU10MW_1WT_Surrogate\n",
+    "from py_wake.superposition_models import LinearSum\n",
+    "from topfarm.utils import regular_generic_layout\n",
+    "from scipy.spatial import ConvexHull\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 'Denmark_good_wind'\n",
+    "examples_sites = pd.read_csv(f'{examples_filepath}examples_sites.csv', index_col=0, sep=';')\n",
+    "ex_site = examples_sites.loc[examples_sites.name == name]\n",
+    "\n",
+    "longitude = ex_site['longitude'].values[0]\n",
+    "latitude = ex_site['latitude'].values[0]\n",
+    "altitude = ex_site['altitude'].values[0]\n",
+    "sim_pars_fn = examples_filepath + ex_site['sim_pars_fn'].values[0]\n",
+    "input_ts_fn = examples_filepath + ex_site['input_ts_fn'].values[0]\n",
+    "\n",
+    "intervals_per_hour = 1\n",
+    "n_wt = 40\n",
+    "n_loads = 4\n",
+    "wt = DTU10MW_1WT_Surrogate()\n",
+    "d = wt.diameter()\n",
+    "site = Hornsrev1Site()\n",
+    "sx = 4 * d\n",
+    "sy = 5 * d\n",
+    "x, y = regular_generic_layout(n_wt, sx, sy, stagger=0, rotation=0)\n",
+    "N_ws = 365 * 24 * intervals_per_hour\n",
+    "time_stamp = np.arange(N_ws) / 6 / 24\n",
+    "farm = NOJ(site, wt, turbulenceModel=STF2017TurbulenceModel(),\n    deflectionModel=JimenezWakeDeflection(), superpositionModel=LinearSum())\n",
+    "yaw = 30 * np.sin(np.arange(N_ws) / 100)\n",
+    "tilt = np.zeros(N_ws)\n",
+    "\n",
+    "hpp = hpp_model(latitude=latitude,\n",
+    "                longitude=longitude,\n",
+    "                altitude=altitude,\n",
+    "                sim_pars_fn=sim_pars_fn,\n",
+    "                input_ts_fn=input_ts_fn,\n",
+    "                intervals_per_hour=intervals_per_hour,\n",
+    "                farm=farm,\n",
+    "                x=x,\n",
+    "                y=y,\n",
+    "                tilt=tilt,\n",
+    "                time_stamp=time_stamp,\n",
+    "                n_loads=n_loads,\n",
+    "                H2_demand_fn=6000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluate the design"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_rated = 10.0\n",
+    "points = np.asarray([x, y]).T\n",
+    "hull = ConvexHull(points)\n",
+    "area = hull.volume * 1e-6\n",
+    "wind_MW_per_km2 = 3\n",
+    "clearance = wt.hub_height() - d / 2\n",
+    "sp = 360\n",
+    "\n",
+    "inputs = dict(clearance=clearance, sp=sp, p_rated=p_rated, Nwt=n_wt, wind_MW_per_km2=wind_MW_per_km2,\n",
+    "              solar_MW=200, surface_tilt=45, surface_azimuth=180, DC_AC_ratio=1.5,\n",
+    "              b_P=40, b_E_h=4, cost_of_battery_P_fluct_in_peak_price_ratio=5,\n",
+    "              ptg_MW=800, HSS_kg=5000,\n",
+    "              yaw=yaw)\n",
+    "\n",
+    "outs = hpp.evaluate(**inputs)\n",
+    "hpp.print_design(list(inputs.values()), outs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting example output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sensors = wt.loadFunction.output_keys\n",
+    "sensor_no = 0\n",
+    "turb = 0\n",
+    "plt.figure()\n",
+    "plt.plot(hpp.prob['loads_rel_ext'][sensor_no, turb, :])\n",
+    "plt.xlabel('Time [h]')\n",
+    "plt.ylabel('Load ratio [-]')\n",
+    "plt.title(f'Extreme loads for {sensors[sensor_no]}')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above figure displays the relative extreme load time series for one wind turbine sensor."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new Jupyter notebook showing how to run the example from `hpp_pywake_p2x.py`
- link the notebook in the documentation index

## Testing
- `pytest -q` *(fails: 4 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_b_684abe5a72888321bc4763a6ddcac80a